### PR TITLE
Enable Emmet in HTML+ERB files

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -9,13 +9,14 @@ repository = "https://github.com/zed-extensions/emmet"
 [language_servers.emmet-language-server]
 name = "Emmet Language Server"
 language = "HTML"
-languages = ["HTML", "PHP", "ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "HEEX", "Elixir", "Vue.js"]
+languages = ["HTML", "PHP", "ERB", "HTML+ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "HEEX", "Elixir", "Vue.js"]
 
 [language_servers.emmet-language-server.language_ids]
 "HTML" = "html"
 "PHP" = "php"
 "ERB" = "eruby"
 "HTML/ERB" = "eruby"
+"HTML+ERB" = "eruby"
 "JavaScript" = "javascriptreact"
 "TSX" = "typescriptreact"
 "CSS" = "css"


### PR DESCRIPTION
Hi! As part of [this issue](https://github.com/zed-extensions/ruby/issues/162) we would like to rename `HTML/ERB` to `HTML+ERB` since it is more syntactically correct to treat such language as ERB on top of HTML rather than HTML or ERB.

To keep the user experience intact, we outlined the prerequisites in the linked issue. This is the first PR that adds the `HTML+ERB` language name to the list of enabled languages for the Emmet extension. We will do the same for the Tailwind configuration in the Zed codebase. Once the new versions of Emmet and Zed are released, we will merge the pull request in the Ruby extension repository and release the updated version. After that, we will remove the old `HTML/ERB` and `YAML/ERB` languages. Let me know if that sounds good. Thanks!