### PR TITLE
Fix language name of `HEEx`

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/zed-extensions/emmet"
 [language_servers.emmet-language-server]
 name = "Emmet Language Server"
 language = "HTML"
-languages = ["HTML", "PHP", "Blade", "ERB", "HTML+ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "SCSS", "LESS", "HEEX", "Elixir", "Vue.js", "Nunjucks", "Django", "Angular", "Jinja2"]
+languages = ["HTML", "PHP", "Blade", "ERB", "HTML+ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "SCSS", "LESS", "HEEx", "HEEX", "Elixir", "Vue.js", "Nunjucks", "Django", "Angular", "Jinja2"]
 
 [language_servers.emmet-language-server.language_ids]
 "HTML" = "html"
@@ -23,6 +23,7 @@ languages = ["HTML", "PHP", "Blade", "ERB", "HTML+ERB", "HTML/ERB", "JavaScript"
 "CSS" = "css"
 "SCSS" = "scss"
 "LESS" = "less"
+"HEEx" = "heex"
 "HEEX" = "heex"
 "Elixir" = "heex"
 "Vue.js" = "vue"

--- a/extension.toml
+++ b/extension.toml
@@ -14,7 +14,6 @@ languages = [
     "Blade",
     "ERB",
     "HTML+ERB",
-    "HTML/ERB",
     "JavaScript",
     "TSX",
     "CSS",
@@ -22,7 +21,6 @@ languages = [
     "LESS",
     "Elixir",
     "HEEx",
-    "HEEX",
     "Vue.js",
     "Nunjucks",
     "Django",
@@ -35,7 +33,6 @@ languages = [
 "PHP" = "php"
 "Blade" = "blade"
 "ERB" = "eruby"
-"HTML/ERB" = "eruby"
 "HTML+ERB" = "eruby"
 "JavaScript" = "javascriptreact"
 "TSX" = "typescriptreact"
@@ -44,7 +41,6 @@ languages = [
 "LESS" = "less"
 "Elixir" = "elixir"
 "HEEx" = "heex"
-"HEEX" = "heex"
 "Vue.js" = "vue"
 "Nunjucks" = "html"
 "Angular" = "angular"

--- a/extension.toml
+++ b/extension.toml
@@ -8,8 +8,27 @@ repository = "https://github.com/zed-extensions/emmet"
 
 [language_servers.emmet-language-server]
 name = "Emmet Language Server"
-language = "HTML"
-languages = ["HTML", "PHP", "Blade", "ERB", "HTML+ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "SCSS", "LESS", "HEEx", "HEEX", "Elixir", "Vue.js", "Nunjucks", "Django", "Angular", "Jinja2"]
+languages = [
+    "HTML",
+    "PHP",
+    "Blade",
+    "ERB",
+    "HTML+ERB",
+    "HTML/ERB",
+    "JavaScript",
+    "TSX",
+    "CSS",
+    "SCSS",
+    "LESS",
+    "Elixir",
+    "HEEx",
+    "HEEX",
+    "Vue.js",
+    "Nunjucks",
+    "Django",
+    "Angular",
+    "Jinja2",
+]
 
 [language_servers.emmet-language-server.language_ids]
 "HTML" = "html"
@@ -23,9 +42,9 @@ languages = ["HTML", "PHP", "Blade", "ERB", "HTML+ERB", "HTML/ERB", "JavaScript"
 "CSS" = "css"
 "SCSS" = "scss"
 "LESS" = "less"
+"Elixir" = "elixir"
 "HEEx" = "heex"
 "HEEX" = "heex"
-"Elixir" = "heex"
 "Vue.js" = "vue"
 "Nunjucks" = "html"
 "Angular" = "angular"


### PR DESCRIPTION
zed-extensions/elixir#61 renames `HEEX` to `HEEx`; to prevent any disruptions from this change, this adds the correct name in tandem with the old one

This also adjusts the language ID for `Elixir`