### PR TITLE
Add `Liquid` to supported languages

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -26,6 +26,7 @@ languages = [
     "Django",
     "Angular",
     "Jinja2",
+    "Liquid",
 ]
 
 [language_servers.emmet-language-server.language_ids]
@@ -46,3 +47,4 @@ languages = [
 "Angular" = "angular"
 "Django" = "html"
 "Jinja2" = "html"
+"Liquid" = "html"


### PR DESCRIPTION
This pull request adds support for the Liquid templating language in the extension configuration. The main updates are in the `extension.toml` file to recognize Liquid files and associate them with the correct language server.

Language support updates:

* Added "Liquid" to the list of supported languages in the `languages` array.
* Mapped "Liquid" to the "html" language ID for the Emmet language server, ensuring proper syntax support.