### PR TITLE
Add Liquid language support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -26,6 +26,7 @@ languages = [
     "Django",
     "Angular",
     "Jinja2",
+    "Liquid",
 ]
 
 [language_servers.emmet-language-server.language_ids]
@@ -46,3 +47,4 @@ languages = [
 "Angular" = "angular"
 "Django" = "html"
 "Jinja2" = "html"
+"Liquid" = "html"


### PR DESCRIPTION
Adds [Shopify Liquid](https://shopify.dev/docs/storefronts/themes/liquid) to the list of supported languages, mapped to `html` as the language ID.

This enables Emmet abbreviation expansion in `.liquid` files when used alongside the [zed-shopify-liquid](https://github.com/TheBeyondGroup/zed-shopify-liquid) extension.

Liquid is an HTML-templating language, so the `html` language ID mapping follows the same pattern used by Django, Nunjucks, and Jinja2.